### PR TITLE
added step to run tests in gitlabs and dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+README.md
+*~
+__pycache__
+.idea
+*pyc
+.DS_Store
+k8charts

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ __pycache__
 .idea
 *pyc
 ~$*
-
+*~
 # Log file directory:
 logs/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ build:
    - docker login -u "${DOCKER_HUB_USER}" --password-stdin < dhpw.txt
    - docker pull $CI_REGISTRY_IMAGE:latest
    - docker build --cache-from $CI_REGISTRY_IMAGE:latest -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+   - docker run $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA pytest
    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   only:
    - master


### PR DESCRIPTION
Before merging this can you add `pytest` into the conda env so we can run it in the container after it is built